### PR TITLE
DOC : 조회  Controller REST docs 추가

### DIFF
--- a/core/core-api/build.gradle
+++ b/core/core-api/build.gradle
@@ -41,14 +41,8 @@ asciidoctor {
         include ("**/index.adoc")
     }
     baseDirFollowsSourceFile()
+    attributes 'snippets': file('build/generated-snippets')
     dependsOn restDocsTest
 }
 
-bootJar {
-    dependsOn asciidoctor
-    print("${asciidoctor.outputDir}")
-    from("${asciidoctor.outputDir}") {
-        into 'src/main/resources/static/docs'
-    }
-}
 

--- a/core/core-api/src/main/java/com/app/community/controller/ArticleQueryController.java
+++ b/core/core-api/src/main/java/com/app/community/controller/ArticleQueryController.java
@@ -17,13 +17,13 @@ public class ArticleQueryController {
     private final ArticleReadService articleReadService;
 
     @GetMapping("")
-    ApiResponse<CursorResult<ArticleInfo>> getArticleList(
+    ApiResponse<CursorResult<ArticleSummary>> getArticleList(
             @RequestParam(name = "sz", required = false, defaultValue = "20") int size,
             @RequestParam(name = "cr", required = false, defaultValue = "-1") Long cursor,
             @RequestParam(name = "tp", required = false) String type
     ) {
         var articles = articleReadService.getLatestArticleList(size, cursor, ArticleType.from(type));
-        var cursorResult = CursorResult.of(articles, size, ArticleInfo::getArticleId);
+        var cursorResult = CursorResult.of(articles, size, ArticleSummary::getId);
         return ApiResponse.success(cursorResult);
     }
 

--- a/core/core-api/src/main/java/com/app/community/controller/ChatQueryController.java
+++ b/core/core-api/src/main/java/com/app/community/controller/ChatQueryController.java
@@ -2,6 +2,7 @@ package com.app.community.controller;
 
 import com.app.community.domain.agg.chat.ChatQuery.*;
 import com.app.community.domain.agg.chat.ChatReadService;
+import com.app.community.domain.agg.member.LoginMember;
 import com.app.community.support.response.ApiResponse;
 import com.app.community.support.response.CursorResult;
 import lombok.RequiredArgsConstructor;
@@ -16,25 +17,25 @@ public class ChatQueryController {
     private final ChatReadService chatReadService;
 
     @GetMapping("")
-    ApiResponse<CursorResult<ChatInfo>> getMyChatList(
-            @AuthenticationPrincipal Long memberId,
+    ApiResponse<CursorResult<ChatSummary>> getMyChatList(
+            @AuthenticationPrincipal LoginMember member,
             @RequestParam(name = "sz", required = false, defaultValue = "20") int size,
             @RequestParam(name = "cr", required = false, defaultValue = "-1") Long cursor
     ) {
-        var chatList = chatReadService.getChatListByMemberId(memberId, size, cursor);
-        var cursorResult = CursorResult.of(chatList, size, ChatInfo::getChatId);
+        var chatList = chatReadService.getChatListByMemberId(member.memberId(), size, cursor);
+        var cursorResult = CursorResult.of(chatList, size, ChatSummary::getId);
         return ApiResponse.success(cursorResult);
     }
 
     @GetMapping("/{chatId}/messages")
     ApiResponse<CursorResult<ChatMessageInfo>> getChatMessageList(
-            @AuthenticationPrincipal Long memberId,
+            @AuthenticationPrincipal LoginMember member,
             @PathVariable(name = "chatId") Long chatId,
             @RequestParam(name = "sz", required = false, defaultValue = "20") int size,
             @RequestParam(name = "cr", required = false, defaultValue = "-1") Long cursor
     ) {
-        var chatMessages = chatReadService.getChatMessageList(memberId, chatId, size, cursor);
-        var cursorResult = CursorResult.of(chatMessages, 20, ChatMessageInfo::getChatId);
+        var chatMessages = chatReadService.getChatMessageList(member.memberId(), chatId, size, cursor);
+        var cursorResult = CursorResult.of(chatMessages, size, ChatMessageInfo::getChatId);
         return ApiResponse.success(cursorResult);
     }
 }

--- a/core/core-api/src/main/java/com/app/community/controller/CommentController.java
+++ b/core/core-api/src/main/java/com/app/community/controller/CommentController.java
@@ -21,7 +21,7 @@ public class CommentController {
             @AuthenticationPrincipal LoginMember member,
             @RequestBody NewCommentRequest request
     ) {
-        commentService.create(member, request.articleId(), request.toTarget(), request.content());
+        commentService.create(member, request.articleId(), request.toTarget(), request.body());
         return ApiResponse.success();
     }
 
@@ -31,7 +31,7 @@ public class CommentController {
             @PathVariable(name = "commentId") Long commentId,
             @RequestBody UpdateRequest request
     ) {
-        commentService.update(member, commentId, request.content());
+        commentService.update(member, commentId, request.body());
         return ApiResponse.success();
     }
 

--- a/core/core-api/src/main/java/com/app/community/controller/CommentQueryController.java
+++ b/core/core-api/src/main/java/com/app/community/controller/CommentQueryController.java
@@ -1,8 +1,9 @@
 package com.app.community.controller;
 
-import com.app.community.domain.agg.comment.CommentQuery.CommentInfo;
+import com.app.community.domain.agg.comment.CommentQuery.*;
 import com.app.community.domain.agg.comment.CommentQuery.ProfileComment;
 import com.app.community.domain.agg.comment.CommentReadService;
+import com.app.community.domain.agg.member.LoginMember;
 import com.app.community.support.response.ApiResponse;
 import com.app.community.support.response.CursorResult;
 import lombok.RequiredArgsConstructor;
@@ -14,26 +15,26 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class CommentQueryController {
 
-    private final CommentReadService commentQueryService;
+    private final CommentReadService commentReadService;
 
     @GetMapping("/{articleId}")
-    ApiResponse<CursorResult<CommentInfo>> getCommentList(
+    ApiResponse<CursorResult<CommentDetails>> getCommentList(
             @PathVariable(name = "articleId") Long articleId,
             @RequestParam(name = "sz", required = false, defaultValue = "20") int size,
             @RequestParam(name = "cr", required = false, defaultValue = "-1") Long cursor
     ){
-        var comments = commentQueryService.getCommentList(articleId, size, cursor);
-        var commentInfo = CursorResult.of(comments, comments.size(), CommentInfo::getCommentId);
+        var comments = commentReadService.getCommentList(articleId, size, cursor);
+        var commentInfo = CursorResult.of(comments, comments.size(), CommentDetails::getId);
         return ApiResponse.success(commentInfo);
     }
 
     @GetMapping("/profiles-answer")
     ApiResponse<CursorResult<ProfileComment>> getAnswerByMember(
-            @AuthenticationPrincipal Long loginMemberId,
-            @RequestParam(name = "s", required = false, defaultValue = "20") int size,
-            @RequestParam(name = "c", required = false, defaultValue = "-1") Long cursor
+            @AuthenticationPrincipal LoginMember member,
+            @RequestParam(name = "sz", required = false, defaultValue = "20") int size,
+            @RequestParam(name = "cr", required = false, defaultValue = "-1") Long cursor
     ) {
-        var comments = commentQueryService.getAnswerByMember(loginMemberId, size, cursor);
+        var comments = commentReadService.getAnswerByMember(member.memberId(), size, cursor);
         var profileComment = CursorResult.of(comments, comments.size(), ProfileComment::getCommentId);
         return ApiResponse.success(profileComment);
     }

--- a/core/core-api/src/main/java/com/app/community/controller/request/ArticleRequests.java
+++ b/core/core-api/src/main/java/com/app/community/controller/request/ArticleRequests.java
@@ -13,12 +13,12 @@ public class ArticleRequests {
 
     public record NewArticleRequest(
             String title,
-            String content,
+            String body,
             String articleType,
             List<String> keywords
     ) {
         public ArticleContent toContent() {
-            return new ArticleContent(title, content);
+            return new ArticleContent(title, body);
         }
 
         public List<KeywordName> toKeywordNames() {
@@ -34,11 +34,11 @@ public class ArticleRequests {
 
     public record UpdateRequest(
             String title,
-            String content,
+            String body,
             List<String> keywords
     ) {
         public ArticleContent toContent() {
-            return new ArticleContent(title, content);
+            return new ArticleContent(title, body);
         }
 
         public List<KeywordName> toKeywordNames() {

--- a/core/core-api/src/main/java/com/app/community/controller/request/CommentRequests.java
+++ b/core/core-api/src/main/java/com/app/community/controller/request/CommentRequests.java
@@ -7,11 +7,10 @@ public class CommentRequests {
 
     public record NewCommentRequest(
             Long articleId,
-            String content,
+            String body,
             Long targetId,
             String targetType
     ){
-
         public CommentTarget toTarget(){
             CommentTargetType targetType = CommentTargetType.from(this.targetType);
             return new CommentTarget(targetId, targetType);
@@ -19,6 +18,8 @@ public class CommentRequests {
     }
 
     public record UpdateRequest(
-            String content
-    ){}
+            String body
+    ){
+
+    }
 }

--- a/core/core-api/src/main/java/com/app/community/support/oauth/JWTFilter.java
+++ b/core/core-api/src/main/java/com/app/community/support/oauth/JWTFilter.java
@@ -38,7 +38,7 @@ public class JWTFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } else {
             Authentication anonymousAuth = new UsernamePasswordAuthenticationToken(
-                    -1L,
+                    new LoginMember(-1L),
                     "anonymousUser",
                     Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
             );

--- a/core/core-api/src/main/java/com/app/community/support/response/CursorResult.java
+++ b/core/core-api/src/main/java/com/app/community/support/response/CursorResult.java
@@ -3,7 +3,6 @@ package com.app.community.support.response;
 import java.util.List;
 
 public record CursorResult<T>(
-        Integer totalElements,
         Long nextCursor,
         Boolean isLast,
         List<T> content
@@ -15,6 +14,6 @@ public record CursorResult<T>(
             T lastItem = items.remove(items.size() - 1);
             nextCursor = cursorExtractor.apply(lastItem) + 1;
         }
-        return new CursorResult<>(items.size(), nextCursor, isLast, items);
+        return new CursorResult<>(nextCursor, isLast, items);
     }
 }

--- a/core/core-api/src/test/java/com/app/community/api_docs/ArticleControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/ArticleControllerRestDocsTest.java
@@ -60,7 +60,7 @@ public class ArticleControllerRestDocsTest extends RestDocsTest {
                                         .type(JsonFieldType.STRING)
                                         .description("제목")
                                         .attributes(key("constraints").value("최소 10자 이상")),
-                                fieldWithPath("content")
+                                fieldWithPath("body")
                                         .type(JsonFieldType.STRING)
                                         .description("본문")
                                         .attributes(key("constraints").value("최소 10자 이상")),
@@ -106,7 +106,7 @@ public class ArticleControllerRestDocsTest extends RestDocsTest {
                                         .type(JsonFieldType.STRING)
                                         .description("제목")
                                         .attributes(key("constraints").value("최소 10자 이상")),
-                                fieldWithPath("content")
+                                fieldWithPath("body")
                                         .type(JsonFieldType.STRING)
                                         .description("본문")
                                         .attributes(key("constraints").value("최소 10자 이상")),

--- a/core/core-api/src/test/java/com/app/community/api_docs/ArticleQueryControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/ArticleQueryControllerRestDocsTest.java
@@ -12,11 +12,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 import static com.app.community.test.api.RestDocsUtils.requestPreprocessor;
 import static com.app.community.test.api.RestDocsUtils.responsePreprocessor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -38,42 +40,42 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
 
     @Test
     void getArticleListTest() {
-
         List<ArticleQuery.ArticleSummary> dummyArticles = List.of(
-                createArticleSummary(1L, "Test Title", "Test Body", "SHARE", "Author1")
-        );
-
+                createArticleSummary(1L, "Test Title", "Test Body", "SHARE", "Author1"));
         when(articleReadService.getLatestArticleList(any(), any(), any())).thenReturn(dummyArticles);
-        given().contentType(ContentType.JSON)
+
+        given()
+                .contentType(ContentType.JSON)
                 .when()
                 .get("/api/articles")
                 .then()
                 .statusCode(HttpStatus.OK.value())
+                .log().all()
                 .apply(document("get-article-list", requestPreprocessor(), responsePreprocessor(),
                         queryParameters(
-                                parameterWithName("sz").optional().description("페이지 크기"),
-                                parameterWithName("cr").optional().description("커서 ID"),
-                                parameterWithName("tp").optional().description("아티클 유형")
+                                parameterWithName("sz").optional().description("페이지 크기 [기본값: 20]"),
+                                parameterWithName("cr").optional().description("커서 대상 ID [기본값: null]"),
+                                parameterWithName("tp").optional().description("아티클 유형 [기본값: null]")
                         ),
                         responseFields(
                                 fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
-                                fieldWithPath("data.nextCursor").type(JsonFieldType.NULL).optional().description("다음 페이지의 커서 (null일 수 있음)"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 시작 대상 ID"),
                                 fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
                                 fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("아티클 리스트"),
-                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).optional().description("아티클 ID (null일 수 있음)"),
-                                fieldWithPath("data.content[].contents.title").type(JsonFieldType.STRING).optional().description("아티클 제목 (null일 수 있음)"),
-                                fieldWithPath("data.content[].contents.body").type(JsonFieldType.STRING).optional().description("아티클 본문 (null일 수 있음)"),
-                                fieldWithPath("data.content[].type").type(JsonFieldType.STRING).optional().description("아티클 유형 (null일 수 있음)"),
-                                fieldWithPath("data.content[].author.id").type(JsonFieldType.NUMBER).optional().description("작성자 ID (null일 수 있음)"),
-                                fieldWithPath("data.content[].author.nickname").type(JsonFieldType.STRING).optional().description("작성자 닉네임 (null일 수 있음)"),
-                                fieldWithPath("data.content[].author.profileImagePath").type(JsonFieldType.STRING).optional().description("작성자 프로필 이미지 경로 (null일 수 있음)"),
-                                fieldWithPath("data.content[].author.createdAt").type(JsonFieldType.STRING).optional().description("작성자 계정 생성일 (null일 수 있음)"),
-                                fieldWithPath("data.content[].author.updatedAt").type(JsonFieldType.STRING).optional().description("작성자 계정 수정일 (null일 수 있음)"),
-                                fieldWithPath("data.content[].keywords[]").type(JsonFieldType.ARRAY).optional().description("키워드 리스트 (null일 수 있음)"),
-                                fieldWithPath("data.content[].keywords[].id").type(JsonFieldType.NUMBER).optional().description("키워드 ID (null일 수 있음)"),
-                                fieldWithPath("data.content[].keywords[].name").type(JsonFieldType.STRING).optional().description("키워드 이름 (null일 수 있음)"),
-                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).optional().description("작성 시간 (null일 수 있음)"),
-                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).optional().description("수정 시간 (null일 수 있음)")
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).optional().description("아티클 ID"),
+                                fieldWithPath("data.content[].contents.title").type(JsonFieldType.STRING).description("아티클 제목"),
+                                fieldWithPath("data.content[].contents.body").type(JsonFieldType.STRING).description("아티클 본문"),
+                                fieldWithPath("data.content[].type").type(JsonFieldType.STRING).optional().description("아티클 유형"),
+                                fieldWithPath("data.content[].author.id").type(JsonFieldType.NUMBER).description("아이클 ID"),
+                                fieldWithPath("data.content[].author.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                fieldWithPath("data.content[].author.profileImagePath").optional().type(JsonFieldType.STRING).description("작성자 프로필 이미지 경로"),
+                                fieldWithPath("data.content[].author.createdAt").type(JsonFieldType.STRING).description("작성자 계정 생성일"),
+                                fieldWithPath("data.content[].author.updatedAt").type(JsonFieldType.STRING).description("작성자 계정 수정일"),
+                                fieldWithPath("data.content[].keywords[]").optional().type(JsonFieldType.ARRAY).description("키워드 리스트"),
+                                fieldWithPath("data.content[].keywords[].id").type(JsonFieldType.NUMBER).description("키워드 ID"),
+                                fieldWithPath("data.content[].keywords[].name").type(JsonFieldType.STRING).description("키워드 이름"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("작성 시간"),
+                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).description("수정 시간")
                         )));
     }
 
@@ -81,13 +83,13 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
     void getArticleDetailsTest() {
         ArticleQuery.ArticleDetails dummyArticle =
                 createArticleDetails(1L, "Test Title", "Test Body", "SHARE", "Author1");
-
-
         when(articleReadService.getArticleDetails(any(), any())).thenReturn(dummyArticle);
+
         given().contentType(ContentType.JSON)
                 .when()
                 .get("/api/articles/{articleId}", String.valueOf(1L))
                 .then()
+                .log().all()
                 .statusCode(HttpStatus.OK.value())
                 .apply(document("get-article-details", requestPreprocessor(), responsePreprocessor(),
                         pathParameters(
@@ -96,31 +98,31 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
                         responseFields(
                                 fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
                                 fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("아티클 ID"),
-                                fieldWithPath("data.contents.title").type(JsonFieldType.STRING).optional().description("아티클 제목 (null일 수 있음)"),
-                                fieldWithPath("data.contents.body").type(JsonFieldType.STRING).optional().description("아티클 본문 (null일 수 있음)"),
-                                fieldWithPath("data.type").type(JsonFieldType.STRING).optional().description("아티클 유형"),
-                                fieldWithPath("data.author.id").type(JsonFieldType.NUMBER).optional().description("작성자 ID"),
-                                fieldWithPath("data.author.nickname").type(JsonFieldType.STRING).optional().description("작성자 닉네임"),
-                                fieldWithPath("data.author.profileImagePath").type(JsonFieldType.STRING).optional().description("작성자 프로필 이미지 경로 (null일 수 있음)"),
-                                fieldWithPath("data.author.createdAt").type(JsonFieldType.STRING).optional().description("작성자 계정 생성일 (null일 수 있음)"),
-                                fieldWithPath("data.author.updatedAt").type(JsonFieldType.STRING).optional().description("작성자 계정 수정일 (null일 수 있음)"),
-                                fieldWithPath("data.keywords").type(JsonFieldType.ARRAY).optional().description("키워드 리스트"),
-                                fieldWithPath("data.keywords[].id").type(JsonFieldType.NUMBER).optional().description("키워드 ID"),
-                                fieldWithPath("data.keywords[].name").type(JsonFieldType.STRING).optional().description("키워드 이름"),
-                                fieldWithPath("data.createdAt").type(JsonFieldType.STRING).optional().description("작성 시간"),
-                                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).optional().description("수정 시간")
+                                fieldWithPath("data.contents.title").type(JsonFieldType.STRING).description("아티클 제목"),
+                                fieldWithPath("data.contents.body").type(JsonFieldType.STRING).description("아티클 본문"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("아티클 유형"),
+                                fieldWithPath("data.author.id").type(JsonFieldType.NUMBER).description("작성자 ID"),
+                                fieldWithPath("data.author.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                fieldWithPath("data.author.profileImagePath").optional().type(JsonFieldType.STRING).description("작성자 프로필 이미지 경로"),
+                                fieldWithPath("data.author.createdAt").type(JsonFieldType.STRING).description("작성자 계정 생성일"),
+                                fieldWithPath("data.author.updatedAt").type(JsonFieldType.STRING).description("작성자 계정 수정일"),
+                                fieldWithPath("data.keywords").optional().type(JsonFieldType.ARRAY).description("키워드 리스트"),
+                                fieldWithPath("data.keywords[].id").type(JsonFieldType.NUMBER).description("키워드 ID"),
+                                fieldWithPath("data.keywords[].name").type(JsonFieldType.STRING).description("키워드 이름"),
+                                fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("작성 시간"),
+                                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).description("수정 시간")
                         )));
     }
 
     @Test
     void getArticleListByMemberTest() {
         List<ArticleQuery.ArticleActivity> dummyArticles = List.of(
-                createArticleActivity(1L, 1L, "Member Title", "Member Body", "SHARE")
-        );
+                createArticleActivity(1L, 1L, "Member Title", "Member Body", "SHARE"));
+        when(articleReadService.getArticleListByMemberId(anyInt(), any(), any(), any())).thenReturn(dummyArticles);
 
-        // Mock 설정
-        when(articleReadService.getArticleListByMemberId(any(), any(), any(), any())).thenReturn(dummyArticles);
-        given().contentType(ContentType.JSON)
+        given().log().all()
+                .body(dummyArticles)
+                .contentType(ContentType.JSON)
                 .header("Authorization", "Bearer token")
                 .when()
                 .get("/api/articles/profiles")
@@ -128,22 +130,21 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
                 .statusCode(HttpStatus.OK.value())
                 .apply(document("get-article-list-by-member", requestPreprocessor(), responsePreprocessor(),
                         queryParameters(
-                                parameterWithName("sz").optional().description("페이지 크기"),
-                                parameterWithName("cr").optional().description("커서 ID"),
-                                parameterWithName("tp").optional().description("아티클 유형")
+                                parameterWithName("sz").optional().description("페이지 크기 [기본값: 20]"),
+                                parameterWithName("cr").optional().description("커서 대상 ID [기본값: null]"),
+                                parameterWithName("tp").optional().description("아티클 유형 [기본값: null]")
                         ),
                         responseFields(
-                                fieldWithPath("result").type(JsonFieldType.STRING).optional().description("성공 여부"),
-                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지의 커서"),
-                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).optional().description("마지막 페이지 여부"),
-                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).optional().description("활동 ID"),
-                                fieldWithPath("data.content[].articleId").type(JsonFieldType.NUMBER).optional().description("아티클 ID"),
-                                fieldWithPath("data.content[].contents.title").type(JsonFieldType.STRING).optional().description("아티클 제목 (null일 수 있음)"),
-                                fieldWithPath("data.content[].contents.body").type(JsonFieldType.STRING).optional().description("아티클 본문 (null일 수 있음)"),
-                                fieldWithPath("data.content[].articleType").type(JsonFieldType.STRING).optional().description("아티클 유형"),
-                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).optional().description("작성 시간"),
-                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).optional().description("수정 시간"),
-                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지의 커서")
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 시작 대상 ID"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).description("아티클 활동 ID"),
+                                fieldWithPath("data.content[].articleId").type(JsonFieldType.NUMBER).description("아티클 ID"),
+                                fieldWithPath("data.content[].contents.title").type(JsonFieldType.STRING).description("아티클 제목"),
+                                fieldWithPath("data.content[].contents.body").type(JsonFieldType.STRING).description("아티클 본문"),
+                                fieldWithPath("data.content[].articleType").type(JsonFieldType.STRING).description("아티클 유형"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("작성 시간"),
+                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).description("마지막 수정 시간")
                         )));
     }
 
@@ -154,7 +155,9 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
         articleSummary.setContents(new ArticleQuery.ArticleContentInfo(title, body));
         articleSummary.setType(ArticleType.valueOf(type));
         articleSummary.setAuthor(new ArticleQuery.ArticleAuthor(1L, authorNickname, null, LocalDateTime.now(), LocalDateTime.now()));
-        articleSummary.setKeywords(List.of(new ArticleQuery.ArticleKeywordInfo()));
+        articleSummary.setKeywords(Collections.emptyList());
+        articleSummary.setCreatedAt(LocalDateTime.now());
+        articleSummary.setUpdatedAt(LocalDateTime.now());
         return articleSummary;
     }
 
@@ -164,7 +167,9 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
         articleDetails.setContents(new ArticleQuery.ArticleContentInfo(title, body));
         articleDetails.setType(ArticleType.valueOf(type));
         articleDetails.setAuthor(new ArticleQuery.ArticleAuthor(1L, authorNickname, null, LocalDateTime.now(), LocalDateTime.now()));
-        articleDetails.setKeywords(List.of(new ArticleQuery.ArticleKeywordInfo()));
+        articleDetails.setKeywords(Collections.emptyList());
+        articleDetails.setCreatedAt(LocalDateTime.now());
+        articleDetails.setUpdatedAt(LocalDateTime.now());
         return articleDetails;
     }
 
@@ -174,6 +179,8 @@ public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
         articleActivity.setArticleId(articleId);
         articleActivity.setContents(new ArticleQuery.ArticleContentInfo(title, body));
         articleActivity.setArticleType(ArticleType.valueOf(articleType));
+        articleActivity.setCreatedAt(LocalDateTime.now());
+        articleActivity.setUpdatedAt(LocalDateTime.now());
         return articleActivity;
     }
 }

--- a/core/core-api/src/test/java/com/app/community/api_docs/ArticleQueryControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/ArticleQueryControllerRestDocsTest.java
@@ -1,0 +1,179 @@
+package com.app.community.api_docs;
+
+import com.app.community.controller.ArticleQueryController;
+import com.app.community.domain.agg.article.ArticleQuery;
+import com.app.community.domain.agg.article.ArticleReadService;
+import com.app.community.domain.agg.article.ArticleType;
+import com.app.community.test.api.RestDocsTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.app.community.test.api.RestDocsUtils.requestPreprocessor;
+import static com.app.community.test.api.RestDocsUtils.responsePreprocessor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+
+public class ArticleQueryControllerRestDocsTest extends RestDocsTest {
+
+    private ArticleReadService articleReadService;
+    private ArticleQueryController articleQueryController;
+
+    @BeforeEach
+    public void setUp() {
+        articleReadService = mock(ArticleReadService.class);
+        articleQueryController = new ArticleQueryController(articleReadService);
+        mockMvc = mockController(articleQueryController);
+    }
+
+    @Test
+    void getArticleListTest() {
+
+        List<ArticleQuery.ArticleSummary> dummyArticles = List.of(
+                createArticleSummary(1L, "Test Title", "Test Body", "SHARE", "Author1")
+        );
+
+        when(articleReadService.getLatestArticleList(any(), any(), any())).thenReturn(dummyArticles);
+        given().contentType(ContentType.JSON)
+                .when()
+                .get("/api/articles")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-article-list", requestPreprocessor(), responsePreprocessor(),
+                        queryParameters(
+                                parameterWithName("sz").optional().description("페이지 크기"),
+                                parameterWithName("cr").optional().description("커서 ID"),
+                                parameterWithName("tp").optional().description("아티클 유형")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NULL).optional().description("다음 페이지의 커서 (null일 수 있음)"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("아티클 리스트"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).optional().description("아티클 ID (null일 수 있음)"),
+                                fieldWithPath("data.content[].contents.title").type(JsonFieldType.STRING).optional().description("아티클 제목 (null일 수 있음)"),
+                                fieldWithPath("data.content[].contents.body").type(JsonFieldType.STRING).optional().description("아티클 본문 (null일 수 있음)"),
+                                fieldWithPath("data.content[].type").type(JsonFieldType.STRING).optional().description("아티클 유형 (null일 수 있음)"),
+                                fieldWithPath("data.content[].author.id").type(JsonFieldType.NUMBER).optional().description("작성자 ID (null일 수 있음)"),
+                                fieldWithPath("data.content[].author.nickname").type(JsonFieldType.STRING).optional().description("작성자 닉네임 (null일 수 있음)"),
+                                fieldWithPath("data.content[].author.profileImagePath").type(JsonFieldType.STRING).optional().description("작성자 프로필 이미지 경로 (null일 수 있음)"),
+                                fieldWithPath("data.content[].author.createdAt").type(JsonFieldType.STRING).optional().description("작성자 계정 생성일 (null일 수 있음)"),
+                                fieldWithPath("data.content[].author.updatedAt").type(JsonFieldType.STRING).optional().description("작성자 계정 수정일 (null일 수 있음)"),
+                                fieldWithPath("data.content[].keywords[]").type(JsonFieldType.ARRAY).optional().description("키워드 리스트 (null일 수 있음)"),
+                                fieldWithPath("data.content[].keywords[].id").type(JsonFieldType.NUMBER).optional().description("키워드 ID (null일 수 있음)"),
+                                fieldWithPath("data.content[].keywords[].name").type(JsonFieldType.STRING).optional().description("키워드 이름 (null일 수 있음)"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).optional().description("작성 시간 (null일 수 있음)"),
+                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).optional().description("수정 시간 (null일 수 있음)")
+                        )));
+    }
+
+    @Test
+    void getArticleDetailsTest() {
+        ArticleQuery.ArticleDetails dummyArticle =
+                createArticleDetails(1L, "Test Title", "Test Body", "SHARE", "Author1");
+
+
+        when(articleReadService.getArticleDetails(any(), any())).thenReturn(dummyArticle);
+        given().contentType(ContentType.JSON)
+                .when()
+                .get("/api/articles/{articleId}", String.valueOf(1L))
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-article-details", requestPreprocessor(), responsePreprocessor(),
+                        pathParameters(
+                                parameterWithName("articleId").description("조회할 아티클 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("아티클 ID"),
+                                fieldWithPath("data.contents.title").type(JsonFieldType.STRING).optional().description("아티클 제목 (null일 수 있음)"),
+                                fieldWithPath("data.contents.body").type(JsonFieldType.STRING).optional().description("아티클 본문 (null일 수 있음)"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).optional().description("아티클 유형"),
+                                fieldWithPath("data.author.id").type(JsonFieldType.NUMBER).optional().description("작성자 ID"),
+                                fieldWithPath("data.author.nickname").type(JsonFieldType.STRING).optional().description("작성자 닉네임"),
+                                fieldWithPath("data.author.profileImagePath").type(JsonFieldType.STRING).optional().description("작성자 프로필 이미지 경로 (null일 수 있음)"),
+                                fieldWithPath("data.author.createdAt").type(JsonFieldType.STRING).optional().description("작성자 계정 생성일 (null일 수 있음)"),
+                                fieldWithPath("data.author.updatedAt").type(JsonFieldType.STRING).optional().description("작성자 계정 수정일 (null일 수 있음)"),
+                                fieldWithPath("data.keywords").type(JsonFieldType.ARRAY).optional().description("키워드 리스트"),
+                                fieldWithPath("data.keywords[].id").type(JsonFieldType.NUMBER).optional().description("키워드 ID"),
+                                fieldWithPath("data.keywords[].name").type(JsonFieldType.STRING).optional().description("키워드 이름"),
+                                fieldWithPath("data.createdAt").type(JsonFieldType.STRING).optional().description("작성 시간"),
+                                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).optional().description("수정 시간")
+                        )));
+    }
+
+    @Test
+    void getArticleListByMemberTest() {
+        List<ArticleQuery.ArticleActivity> dummyArticles = List.of(
+                createArticleActivity(1L, 1L, "Member Title", "Member Body", "SHARE")
+        );
+
+        // Mock 설정
+        when(articleReadService.getArticleListByMemberId(any(), any(), any(), any())).thenReturn(dummyArticles);
+        given().contentType(ContentType.JSON)
+                .header("Authorization", "Bearer token")
+                .when()
+                .get("/api/articles/profiles")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-article-list-by-member", requestPreprocessor(), responsePreprocessor(),
+                        queryParameters(
+                                parameterWithName("sz").optional().description("페이지 크기"),
+                                parameterWithName("cr").optional().description("커서 ID"),
+                                parameterWithName("tp").optional().description("아티클 유형")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).optional().description("성공 여부"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지의 커서"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).optional().description("마지막 페이지 여부"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).optional().description("활동 ID"),
+                                fieldWithPath("data.content[].articleId").type(JsonFieldType.NUMBER).optional().description("아티클 ID"),
+                                fieldWithPath("data.content[].contents.title").type(JsonFieldType.STRING).optional().description("아티클 제목 (null일 수 있음)"),
+                                fieldWithPath("data.content[].contents.body").type(JsonFieldType.STRING).optional().description("아티클 본문 (null일 수 있음)"),
+                                fieldWithPath("data.content[].articleType").type(JsonFieldType.STRING).optional().description("아티클 유형"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).optional().description("작성 시간"),
+                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).optional().description("수정 시간"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지의 커서")
+                        )));
+    }
+
+
+    private ArticleQuery.ArticleSummary createArticleSummary(Long id, String title, String body, String type, String authorNickname) {
+        ArticleQuery.ArticleSummary articleSummary = new ArticleQuery.ArticleSummary();
+        articleSummary.setId(id);
+        articleSummary.setContents(new ArticleQuery.ArticleContentInfo(title, body));
+        articleSummary.setType(ArticleType.valueOf(type));
+        articleSummary.setAuthor(new ArticleQuery.ArticleAuthor(1L, authorNickname, null, LocalDateTime.now(), LocalDateTime.now()));
+        articleSummary.setKeywords(List.of(new ArticleQuery.ArticleKeywordInfo()));
+        return articleSummary;
+    }
+
+    private ArticleQuery.ArticleDetails createArticleDetails(Long id, String title, String body, String type, String authorNickname) {
+        ArticleQuery.ArticleDetails articleDetails = new ArticleQuery.ArticleDetails();
+        articleDetails.setId(id);
+        articleDetails.setContents(new ArticleQuery.ArticleContentInfo(title, body));
+        articleDetails.setType(ArticleType.valueOf(type));
+        articleDetails.setAuthor(new ArticleQuery.ArticleAuthor(1L, authorNickname, null, LocalDateTime.now(), LocalDateTime.now()));
+        articleDetails.setKeywords(List.of(new ArticleQuery.ArticleKeywordInfo()));
+        return articleDetails;
+    }
+
+    private ArticleQuery.ArticleActivity createArticleActivity(Long id, Long articleId, String title, String body, String articleType) {
+        ArticleQuery.ArticleActivity articleActivity = new ArticleQuery.ArticleActivity();
+        articleActivity.setId(id);
+        articleActivity.setArticleId(articleId);
+        articleActivity.setContents(new ArticleQuery.ArticleContentInfo(title, body));
+        articleActivity.setArticleType(ArticleType.valueOf(articleType));
+        return articleActivity;
+    }
+}

--- a/core/core-api/src/test/java/com/app/community/api_docs/ChatQueryControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/ChatQueryControllerRestDocsTest.java
@@ -1,0 +1,130 @@
+package com.app.community.api_docs;
+
+import com.app.community.controller.ChatQueryController;
+import com.app.community.domain.agg.chat.ChatQuery.*;
+import com.app.community.domain.agg.chat.ChatReadService;
+import com.app.community.domain.agg.chat.MessageType;
+import com.app.community.test.api.RestDocsTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.app.community.test.api.RestDocsUtils.requestPreprocessor;
+import static com.app.community.test.api.RestDocsUtils.responsePreprocessor;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
+public class ChatQueryControllerRestDocsTest extends RestDocsTest {
+
+    private ChatReadService chatReadService;
+    private ChatQueryController chatQueryController;
+
+    @BeforeEach
+    public void setUp() {
+        chatReadService = mock(ChatReadService.class);
+        chatQueryController = new ChatQueryController(chatReadService);
+        mockMvc = mockController(chatQueryController);
+    }
+
+    @Test
+    void getMyChatList() {
+        var chatList = List.of(
+                new ChatSummary(1L, new Participant(1L, "user1"), new Participant(2L, "user2"), "마지막 메시지", LocalDateTime.now(),
+                        new ChatDateTimeInfo(LocalDateTime.now(), LocalDateTime.now())),
+                new ChatSummary(2L, new Participant(1L, "user1"), new Participant(3L, "user3"), "마지막 메시지2", LocalDateTime.now(),
+                        new ChatDateTimeInfo(LocalDateTime.now(), LocalDateTime.now()))
+        );
+
+        when(chatReadService.getChatListByMemberId(any(), anyInt(), any()))
+                .thenReturn(chatList);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Authorization", "Bearer token")
+                .param("sz", 20)
+                .param("cr", -1)
+                .when()
+                .get("/api/chats")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-my-chat-list",
+                        requestPreprocessor(),
+                        responsePreprocessor(),
+                        queryParameters(
+                                parameterWithName("sz").description("가져올 채팅 수").optional(),
+                                parameterWithName("cr").description("커서").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 시작 대상 ID"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("채팅 리스트"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).description("채팅 ID"),
+                                fieldWithPath("data.content[].sender.id").type(JsonFieldType.NUMBER).description("발신자 ID"),
+                                fieldWithPath("data.content[].sender.nickname").type(JsonFieldType.STRING).description("발신자 닉네임"),
+                                fieldWithPath("data.content[].receiver.id").type(JsonFieldType.NUMBER).description("수신자 ID"),
+                                fieldWithPath("data.content[].receiver.nickname").type(JsonFieldType.STRING).description("수신자 닉네임"),
+                                fieldWithPath("data.content[].lastMessage").type(JsonFieldType.STRING).description("마지막 메시지"),
+                                fieldWithPath("data.content[].lastUpdatedAt").type(JsonFieldType.STRING).description("마지막 메시지 업데이트 시간"),
+                                fieldWithPath("data.content[].period.createdAt").type(JsonFieldType.STRING).description("채팅방 생성 시간"),
+                                fieldWithPath("data.content[].period.endDate").type(JsonFieldType.STRING).description("채팅 종료 날짜")
+                        )));
+    }
+
+    @Test
+    void getChatMessageList() {
+        var chatMessages = List.of(
+                new ChatMessageInfo(1L, 1L, new Participant(1L, "user1"), "메시지 본문", LocalDateTime.now(), MessageType.MESSAGE, true),
+                new ChatMessageInfo(2L, 1L, new Participant(2L, "user2"), "메시지 본문2", LocalDateTime.now(), MessageType.MESSAGE, false)
+        );
+
+        when(chatReadService.getChatMessageList(any(), anyLong(), anyInt(), any()))
+                .thenReturn(chatMessages);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Authorization", "Bearer token")
+                .param("sz", 20)
+                .param("cr", -1)
+                .when()
+                .get("/api/chats/{chatId}/messages", String.valueOf(1L  ))
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-chat-message-list",
+                        requestPreprocessor(),
+                        responsePreprocessor(),
+                        queryParameters(
+                                parameterWithName("sz").description("가져올 메시지 수").optional(),
+                                parameterWithName("cr").description("커서").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 시작 대상 ID"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("메시지 리스트"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).description("메시지 ID"),
+                                fieldWithPath("data.content[].chatId").type(JsonFieldType.NUMBER).description("채팅방 ID"),
+                                fieldWithPath("data.content[].sender.id").type(JsonFieldType.NUMBER).description("발신자 ID"),
+                                fieldWithPath("data.content[].sender.nickname").type(JsonFieldType.STRING).description("발신자 닉네임"),
+                                fieldWithPath("data.content[].body").type(JsonFieldType.STRING).description("메시지 본문"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("메시지 생성 시간"),
+                                fieldWithPath("data.content[].messageType").type(JsonFieldType.STRING).description("메시지 타입"),
+                                fieldWithPath("data.content[].isRead").type(JsonFieldType.BOOLEAN).description("메시지 읽음 여부")
+                        )));
+    }
+}

--- a/core/core-api/src/test/java/com/app/community/api_docs/CommentControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/CommentControllerRestDocsTest.java
@@ -58,7 +58,7 @@ public class CommentControllerRestDocsTest extends RestDocsTest {
                                         .type(JsonFieldType.NUMBER)
                                         .description("아티클 ID")
                                         .attributes(key("constraints").value("댓글을 작성하는 아티클 ID")),
-                                fieldWithPath("content")
+                                fieldWithPath("body")
                                         .type(JsonFieldType.STRING)
                                         .description("댓글 내용")
                                         .attributes(key("constraints").value("최소 1자 이상, 200자 이하.")),
@@ -102,7 +102,7 @@ public class CommentControllerRestDocsTest extends RestDocsTest {
                                         .description("수정할 댓글의 ID")
                         ),
                         requestFields(
-                                fieldWithPath("content")
+                                fieldWithPath("body")
                                         .type(JsonFieldType.STRING)
                                         .description("수정된 댓글 내용")
                                         .attributes(key("constraints").value("최소 1자 이상, 200자 이하."))

--- a/core/core-api/src/test/java/com/app/community/api_docs/CommentQueryControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/CommentQueryControllerRestDocsTest.java
@@ -1,4 +1,142 @@
 package com.app.community.api_docs;
 
-public class CommentQueryControllerRestDocsTest {
+import com.app.community.controller.CommentQueryController;
+import com.app.community.domain.agg.comment.*;
+import com.app.community.domain.agg.comment.CommentQuery.CommentDetails;
+import com.app.community.domain.agg.comment.CommentQuery.ProfileComment;
+
+import com.app.community.test.api.RestDocsTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.app.community.test.api.RestDocsUtils.requestPreprocessor;
+import static com.app.community.test.api.RestDocsUtils.responsePreprocessor;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+
+public class CommentQueryControllerRestDocsTest extends RestDocsTest {
+
+    private CommentReadService commentReadService;
+    private CommentQueryController commentQueryController;
+
+    @BeforeEach
+    public void setUp() {
+        commentReadService = mock(CommentReadService.class);
+        commentQueryController = new CommentQueryController(commentReadService);
+        mockMvc = mockController(commentQueryController);
+    }
+
+    @Test
+    void getCommentList() {
+        var author = new CommentQuery.CommentAuthor(1L, "user1", null, LocalDateTime.now(), LocalDateTime.now());
+        var childComment = new CommentDetails(2L, 1L, 1L, "대댓글 내용", CommentStatus.STEADY, author, List.of(), LocalDateTime.now(), LocalDateTime.now());
+        var commentDetails = List.of(
+                new CommentDetails(1L, 1L, null, "댓글 내용", CommentStatus.STEADY, author, List.of(childComment), LocalDateTime.now(), LocalDateTime.now())
+        );
+
+        when(commentReadService.getCommentList(anyLong(), anyInt(), anyLong()))
+                .thenReturn(commentDetails);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/api/comments/{articleId}", String.valueOf(1L))
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-comment-list",
+                        requestPreprocessor(),
+                        responsePreprocessor(),
+                        queryParameters(
+                                parameterWithName("sz").description("가져올 댓글 수").optional(),
+                                parameterWithName("cr").description("커서").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 시작 대상 ID"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER).description("댓글 ID"),
+                                fieldWithPath("data.content[].articleId").type(JsonFieldType.NUMBER).description("아티클 ID"),
+                                fieldWithPath("data.content[].parentId").type(JsonFieldType.NUMBER).description("부모 댓글 ID"),
+                                fieldWithPath("data.content[].body").type(JsonFieldType.STRING).description("댓글 내용"),
+                                fieldWithPath("data.content[].status").type(JsonFieldType.STRING).description("댓글 상태"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("댓글 생성 날짜"),
+                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).description("댓글 수정 날짜"),
+                                fieldWithPath("data.content[].author.id").type(JsonFieldType.NUMBER).description("작성자 ID"),
+                                fieldWithPath("data.content[].author.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                fieldWithPath("data.content[].author.profileImagePath").type(JsonFieldType.STRING).optional().description("작성자 프로필 이미지 경로"),
+                                fieldWithPath("data.content[].author.createdAt").type(JsonFieldType.STRING).description("작성자 생성 날짜"),
+                                fieldWithPath("data.content[].author.updatedAt").type(JsonFieldType.STRING).description("작성자 수정 날짜"),
+                                fieldWithPath("data.content[].children").type(JsonFieldType.ARRAY).description("대댓글 목록"),
+                                fieldWithPath("data.content[].children[].id").type(JsonFieldType.NUMBER).description("대댓글 ID"),
+                                fieldWithPath("data.content[].children[].articleId").type(JsonFieldType.NUMBER).description("대댓글이 속한 아티클 ID"),
+                                fieldWithPath("data.content[].children[].parentId").type(JsonFieldType.NUMBER).description("부모 댓글 ID"),
+                                fieldWithPath("data.content[].children[].body").type(JsonFieldType.STRING).description("대댓글 내용"),
+                                fieldWithPath("data.content[].children[].status").type(JsonFieldType.STRING).description("대댓글 상태"),
+                                fieldWithPath("data.content[].children[].createdAt").type(JsonFieldType.STRING).description("대댓글 생성 날짜"),
+                                fieldWithPath("data.content[].children[].updatedAt").type(JsonFieldType.STRING).description("대댓글 수정 날짜"),
+                                fieldWithPath("data.content[].children[].author.id").type(JsonFieldType.NUMBER).description("대댓글 작성자 ID"),
+                                fieldWithPath("data.content[].children[].author.nickname").type(JsonFieldType.STRING).description("대댓글 작성자 닉네임"),
+                                fieldWithPath("data.content[].children[].author.profileImagePath").type(JsonFieldType.STRING).optional().description("대댓글 작성자 프로필 이미지 경로"),
+                                fieldWithPath("data.content[].children[].author.createdAt").type(JsonFieldType.STRING).description("대댓글 작성자 생성 날짜"),
+                                fieldWithPath("data.content[].children[].author.updatedAt").type(JsonFieldType.STRING).description("대댓글 작성자 수정 날짜"),
+                                fieldWithPath("data.content[].children[].children").type(JsonFieldType.ARRAY).description("대대댓글 목록 [없음]")
+                        )));
+    }
+
+    @Test
+    void getAnswerByMember() {
+        var profileComments = List.of(
+                new ProfileComment(1L, 1L, "아티클 제목", "답글 내용", LocalDateTime.now(), LocalDateTime.now()),
+                new ProfileComment(2L, 1L, "아티클 제목", "답글 내용2", LocalDateTime.now(), LocalDateTime.now())
+        );
+
+
+        when(commentReadService.getAnswerByMember(any(), anyInt(), any()))
+                .thenReturn(profileComments);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Authorization", "Bearer token")
+                .param("sz", 20)
+                .param("cr", -1)
+                .when()
+                .get("/api/comments/profiles-answer")
+                .then()
+                .log().all()  // 응답 로그를 확인
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("get-answer-by-member",
+                        requestPreprocessor(),
+                        responsePreprocessor(),
+                        queryParameters(
+                                parameterWithName("sz").description("가져올 답글 수").optional(),
+                                parameterWithName("cr").description("커서").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("성공 여부"),
+                                fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("댓글 리스트"),
+                                fieldWithPath("data.content[].commentId").type(JsonFieldType.NUMBER).description("댓글 ID"),
+                                fieldWithPath("data.content[].articleId").type(JsonFieldType.NUMBER).description("아티클 ID"),
+                                fieldWithPath("data.content[].articleTitle").type(JsonFieldType.STRING).description("아티클 제목"),
+                                fieldWithPath("data.content[].commentBody").type(JsonFieldType.STRING).description("댓글 내용"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("댓글 생성 날짜"),
+                                fieldWithPath("data.content[].updatedAt").type(JsonFieldType.STRING).description("댓글 수정 날짜"),
+                                fieldWithPath("data.nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지의 커서"),
+                                fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부")
+                        )));
+
+    }
+
 }

--- a/core/core-api/src/test/java/com/app/community/api_docs/CommentQueryControllerRestDocsTest.java
+++ b/core/core-api/src/test/java/com/app/community/api_docs/CommentQueryControllerRestDocsTest.java
@@ -1,0 +1,4 @@
+package com.app.community.api_docs;
+
+public class CommentQueryControllerRestDocsTest {
+}

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleContent.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleContent.java
@@ -2,6 +2,6 @@ package com.app.community.domain.agg.article;
 
 public record ArticleContent(
         String title,
-        String content
+        String body
 ) {
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleQuery.java
@@ -1,65 +1,78 @@
 package com.app.community.domain.agg.article;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public class ArticleQuery {
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class ArticleDetails {
-        private final Long articleId;
-        private final String title;
-        private final String content;
-        private final ArticleType articleType;
-        private final Author author;
-        private final LocalDateTime createdAt;
-        private final LocalDateTime updatedAt;
-        private final List<ArticleKeywordInfo> keywordList;
+        private Long id;
+        private ArticleContentInfo contents;
+        private ArticleAuthor author;
+        private ArticleType type;
+        private List<ArticleKeywordInfo> keywords;
+        private LocalDateTime updatedAt;
+        private LocalDateTime createdAt;
     }
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
-    public static class ArticleInfo {
-        private final Long articleId;
-        private final String title;
-        private final String content;
-        private final ArticleType articleType;
-        private final Author author;
-        private final LocalDateTime createdAt;
-        private final LocalDateTime updatedAt;
-        private final List<ArticleKeywordInfo> keywordList;
+    public static class ArticleSummary {
+        private Long id;
+        private ArticleContentInfo contents;
+        private ArticleType type;
+        private ArticleAuthor author;
+        private List<ArticleKeywordInfo> keywords;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
 
-    @Getter
-    @AllArgsConstructor
-    public static class Author {
-        private final Long memberId;
-        private final String nickname;
-        private final String profileImagePath;
-        private final LocalDateTime createdAt;
-        private final LocalDateTime updatedAt;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class ArticleKeywordInfo {
-        private final Long keywordId;
-        private final String keywordName;
-    }
-
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class ArticleActivity {
-        private final Long id;
-        private final Long articleId;
-        private final String title;
-        private final String content;
-        private final ArticleType articleType;
-        private final LocalDateTime createdAt;
-        private final LocalDateTime updatedAt;
+        private Long id;
+        private Long articleId;
+        private ArticleContentInfo contents;
+        private ArticleType articleType;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ArticleContentInfo {
+        private String title;
+        private String body;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ArticleKeywordInfo {
+        private Long id;
+        private String
+                name;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ArticleAuthor {
+        private Long id;
+        private String nickname;
+        private String profileImagePath;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleReadService.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleReadService.java
@@ -16,11 +16,11 @@ public class ArticleReadService {
         return articleRepositoryForQuery.findArticleDetails(articleId, memberId);
     }
 
-    public List<ArticleInfo> getLatestArticleList(int size, Long cursor, ArticleType type){
+    public List<ArticleSummary> getLatestArticleList(Integer size, Long cursor, ArticleType type){
         return articleRepositoryForQuery.findArticleList(size, cursor, type);
     }
 
-    public List<ArticleActivity> getArticleListByMemberId(int size, Long cursor, ArticleType type, Long memberId) {
+    public List<ArticleActivity> getArticleListByMemberId(Integer size, Long cursor, ArticleType type, Long memberId) {
         return articleRepositoryForQuery.findArticleListByMemberId(size, cursor, type, memberId);
     }
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleRepositoryForQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleRepositoryForQuery.java
@@ -5,7 +5,7 @@ import com.app.community.domain.agg.article.ArticleQuery.*;
 import java.util.List;
 
 public interface ArticleRepositoryForQuery {
-    List<ArticleInfo> findArticleList(int size, Long cursor, ArticleType type);
+    List<ArticleSummary> findArticleList(int size, Long cursor, ArticleType type);
     ArticleDetails findArticleDetails(Long articleId, Long memberId);
     List<ArticleActivity> findArticleListByMemberId(int size, Long cursor, ArticleType type, Long memberId);
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleType.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/article/ArticleType.java
@@ -13,6 +13,6 @@ public enum ArticleType {
         return Arrays.stream(ArticleType.values())
                 .filter(articleType -> articleType.name().equalsIgnoreCase(type))
                 .findFirst()
-                .orElseThrow(() -> new DomainException(DomainErrorType.INVALID_ARTICLE_TYPE));
+                .orElse(null);
     }
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/chat/ChatQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/chat/ChatQuery.java
@@ -3,40 +3,51 @@ package com.app.community.domain.agg.chat;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class ChatQuery {
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChatInfo {
-        private Long chatId;
+    public static class ChatSummary {
+        private Long id;
         private Participant sender;
         private Participant receiver;
-        private String lastMessages;
+        private String lastMessage;
         private LocalDateTime lastUpdatedAt;
-        private LocalDateTime createdAt;
-        private LocalDateTime endDate;
-
+        private ChatDateTimeInfo period;
     }
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class ChatMessageInfo {
+        private Long id;
         private Long chatId;
-        private Long messageId;
         private Participant sender;
-        private String content;
+        private String body;
         private LocalDateTime createdAt;
         private MessageType messageType;
         private Boolean isRead;
 
     }
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class Participant {
-        private Long memberId;
+        private Long id;
         private String nickname;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatDateTimeInfo{
+        private LocalDateTime createdAt;
+        private LocalDateTime endDate;
     }
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/chat/ChatReadService.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/chat/ChatReadService.java
@@ -13,7 +13,7 @@ public class ChatReadService {
 
     private final ChatRepositoryForQuery chatRepositoryForQuery;
 
-    public List<ChatInfo> getChatListByMemberId(Long memberId, int size, Long cursor) {
+    public List<ChatSummary> getChatListByMemberId(Long memberId, int size, Long cursor) {
         return chatRepositoryForQuery.findChatListByMemberId(memberId, size, cursor);
     }
 

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/chat/ChatRepositoryForQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/chat/ChatRepositoryForQuery.java
@@ -5,6 +5,6 @@ import com.app.community.domain.agg.chat.ChatQuery.*;
 import java.util.List;
 
 public interface ChatRepositoryForQuery {
-    List<ChatInfo> findChatListByMemberId(Long memberId, int size, Long cursor);
+    List<ChatSummary> findChatListByMemberId(Long memberId, int size, Long cursor);
     List<ChatMessageInfo> findChatMessageList(Long memberId, Long chatId, int size, Long cursor);
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/chat/Message.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/chat/Message.java
@@ -9,7 +9,7 @@ public class Message {
     private Long id;
     private Long chatId;
     private Long senderId;
-    private String content;
+    private String body;
     private Boolean isRead;
     private MessageType messageType;
 
@@ -18,24 +18,24 @@ public class Message {
             Long id,
             Long chatId,
             Long senderId,
-            String content,
+            String body,
             Boolean isRead,
             MessageType messageType
     ) {
         this.id = id;
         this.chatId = chatId;
         this.senderId = senderId;
-        this.content = content;
+        this.body = body;
         this.isRead = isRead;
         this.messageType = messageType;
     }
 
-    public static Message create(Long senderId, String content, Long chatId) {
+    public static Message create(Long senderId, String body, Long chatId) {
         return Message.builder()
                 .chatId(chatId)
                 .senderId(senderId)
                 .messageType(MessageType.MESSAGE)
-                .content(content)
+                .body(body)
                 .isRead(false)
                 .build();
     }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/comment/Comment.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/comment/Comment.java
@@ -9,15 +9,15 @@ public class Comment {
     private final Long id;
     private final Long writerId;
     private final Long articleId;
+    private String body;
     private final CommentTarget target;
-    private String content;
     private CommentStatus status;
 
     public Comment(
             Long id,
             Long writerId,
             Long articleId,
-            String content,
+            String body,
             CommentTarget target,
             CommentStatus status
     ) {
@@ -25,22 +25,22 @@ public class Comment {
         this.writerId = writerId;
         this.articleId = articleId;
         this.target = target;
-        this.content = content;
+        this.body = body;
         this.status = status;
     }
 
     public static Comment create(
             Long writerId,
             Long articleId,
-            String content,
+            String body,
             CommentTarget target
     ) {
-        return new Comment(null, writerId, articleId, content, target, CommentStatus.STEADY);
+        return new Comment(null, writerId, articleId, body, target, CommentStatus.STEADY);
     }
 
-    public void update(Long memberId, String content){
+    public void update(Long memberId, String body){
         validateWriter(memberId);
-        this.content = content;
+        this.body = body;
     }
 
     public void withdrawal(Long memberId){

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentQuery.java
@@ -16,7 +16,7 @@ public class CommentQuery {
         private Long parentId;
         private String content;
         private CommentStatus status;
-        private Author author;
+        private CommentAuthor commentAuthor;
         private List<CommentInfo> childCommentList;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
@@ -24,7 +24,7 @@ public class CommentQuery {
 
     @Getter
     @AllArgsConstructor
-    public static class Author {
+    public static class CommentAuthor {
         private Long memberId;
         private String nickname;
         private String profileImagePath;

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentQuery.java
@@ -1,31 +1,34 @@
 package com.app.community.domain.agg.comment;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public class CommentQuery {
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
-    public static class CommentInfo {
-        private Long commentId;
+    public static class CommentDetails {
+        private Long id;
         private Long articleId;
         private Long parentId;
-        private String content;
+        private String body;
         private CommentStatus status;
-        private CommentAuthor commentAuthor;
-        private List<CommentInfo> childCommentList;
+        private CommentAuthor author;
+        private List<CommentDetails> children;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class CommentAuthor {
-        private Long memberId;
+        private Long id;
         private String nickname;
         private String profileImagePath;
         private LocalDateTime createdAt;
@@ -33,14 +36,14 @@ public class CommentQuery {
 
     }
 
-    @Getter
+    @Data
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class ProfileComment {
         private Long commentId;
         private Long articleId;
         private String articleTitle;
-        private String content;
-        private CommentStatus status;
+        private String commentBody;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentReadService.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentReadService.java
@@ -1,6 +1,6 @@
 package com.app.community.domain.agg.comment;
 
-import com.app.community.domain.agg.comment.CommentQuery.CommentInfo;
+import com.app.community.domain.agg.comment.CommentQuery.CommentDetails;
 import com.app.community.domain.agg.comment.CommentQuery.ProfileComment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -13,7 +13,7 @@ public class CommentReadService {
 
     private final CommentRepositoryForQuery commentRepositoryForQuery;
 
-    public List<CommentInfo> getCommentList(Long articleId, int size, Long cursor){
+    public List<CommentDetails> getCommentList(Long articleId, int size, Long cursor){
         return commentRepositoryForQuery.findCommentListByArticleId(articleId, size, cursor);
     }
 

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentRepositoryForQuery.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentRepositoryForQuery.java
@@ -5,7 +5,7 @@ import com.app.community.domain.agg.comment.CommentQuery.*;
 import java.util.List;
 
 public interface CommentRepositoryForQuery {
-    List<CommentInfo> findCommentListByArticleId(Long articleId, int size, Long cursor);
+    List<CommentDetails> findCommentListByArticleId(Long articleId, int size, Long cursor);
 
     List<ProfileComment> findAnswerByMember(Long memberId, int size, Long cursor);
 }

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentService.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/comment/CommentService.java
@@ -13,8 +13,8 @@ public class CommentService {
     private final CommentReader commentReader;
     private final PointProcessor pointProcessor;
 
-    public void create(LoginMember member, Long articleId, CommentTarget target, String content) {
-        var comment = commentWriter.append(member.memberId(), articleId, target, content);
+    public void create(LoginMember member, Long articleId, CommentTarget target, String body) {
+        var comment = commentWriter.append(member.memberId(), articleId, target, body);
         pointProcessor.rewardCommenting(member.memberId(), comment.getId());
     }
 

--- a/core/core-domain/src/main/java/com/app/community/domain/agg/member/MemberReader.java
+++ b/core/core-domain/src/main/java/com/app/community/domain/agg/member/MemberReader.java
@@ -1,5 +1,7 @@
 package com.app.community.domain.agg.member;
 
+import com.app.community.domain.support.error.DomainErrorType;
+import com.app.community.domain.support.error.DomainException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/ArticleEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/ArticleEntity.java
@@ -16,12 +16,21 @@ public class ArticleEntity extends AbstractEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "writer_id")
     private Long writerId;
+
+    @Column(name = "title")
     private String title;
-    @Lob
-    private String content;
+
+    @Lob @Column(name = "body")
+    private String body;
+
+    @Column(name ="type")
     @Enumerated(EnumType.STRING)
     private ArticleType type;
+
+    @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private ArticleStatus status;
 

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/ArticleEntityConverter.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/ArticleEntityConverter.java
@@ -17,7 +17,7 @@ public class ArticleEntityConverter {
                 article.getId(),
                 article.getWriterId(),
                 article.getContent().title(),
-                article.getContent().content(),
+                article.getContent().body(),
                 article.getType(),
                 article.getStatus()
         );
@@ -32,7 +32,7 @@ public class ArticleEntityConverter {
     public static Article toDomain(ArticleEntity articleEntity, List<ArticleKeywordEntity> articleKeywordEntities) {
         if (articleEntity == null) return null;
 
-        ArticleContent content = new ArticleContent(articleEntity.getTitle(), articleEntity.getContent());
+        ArticleContent content = new ArticleContent(articleEntity.getTitle(), articleEntity.getBody());
 
         Set<Long> ids = articleKeywordEntities.stream()
                 .map(ArticleKeywordEntity::getId)

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/ArticleKeywordEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/ArticleKeywordEntity.java
@@ -14,6 +14,10 @@ public class ArticleKeywordEntity extends AbstractEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "article_id")
     private Long articleId;
+
+    @Column(name = "keyword_id")
     private Long keywordId;
 }

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/KeywordCoreRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/KeywordCoreRepository.java
@@ -21,7 +21,7 @@ public class KeywordCoreRepository implements KeywordRepository {
                 .map(KeywordName::value)
                 .collect(Collectors.toList());
 
-        return keywordJpaRepository.findByKeywordNameIn(toString).stream()
+        return keywordJpaRepository.findByNameIn(toString).stream()
                 .map(KeywordEntity::toDomain)
                 .collect(Collectors.toList());
     }

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/KeywordEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/KeywordEntity.java
@@ -16,9 +16,17 @@ public class KeywordEntity extends AbstractEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String keywordName;
+
+    @Column(name = "name")
+    private String name;
+
+    public static KeywordEntity fromDomain(Keyword keyword){
+        return KeywordEntity.builder()
+                .name(keyword.getName().value())
+                .build();
+    }
 
     public Keyword toDomain(){
-        return new Keyword(id, new KeywordName(keywordName));
+        return new Keyword(id, new KeywordName(name));
     }
 }

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/KeywordJpaRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/aritcle/KeywordJpaRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface KeywordJpaRepository extends JpaRepository<KeywordEntity, Long> {
-    List<KeywordEntity> findByKeywordNameIn(List<String> keywordName);
+    List<KeywordEntity> findByNameIn(List<String> keywordName);
 }

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/ChatCoreRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/ChatCoreRepository.java
@@ -20,9 +20,9 @@ public class ChatCoreRepository implements ChatRepository {
                 chat.getId(),
                 chat.getParticipant().respondentId(),
                 chat.getParticipant().requesterId(),
-                chat.getStatus(),
                 chat.getChatDateTime().createdAt(),
-                chat.getChatDateTime().endAt()
+                chat.getChatDateTime().endAt(),
+                chat.getStatus()
         );
         return chatJpaRepository.save(chatEntity).toDomain();
     }

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/ChatEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/ChatEntity.java
@@ -17,14 +17,15 @@ import java.time.LocalDateTime;
 @Entity
 public class ChatEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long respondentId;
     private Long requesterId;
-    private ChatStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime endAt;
+
+    @Enumerated(EnumType.STRING)
+    private ChatStatus status;
 
 
     public Chat toDomain() {

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/ChatEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/ChatEntity.java
@@ -11,17 +11,26 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "chats")
 @Entity
 public class ChatEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "respondent_id")
     private Long respondentId;
+
+    @Column(name = "requester_id")
     private Long requesterId;
+
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
+
+    @Column(name = "end_at")
     private LocalDateTime endAt;
 
     @Enumerated(EnumType.STRING)

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/MessageEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/MessageEntity.java
@@ -4,12 +4,11 @@ import com.app.community.domain.agg.chat.Message;
 import com.app.community.domain.agg.chat.MessageType;
 import com.app.community.storage.db.command.AbstractEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "chat_messages")
 @Entity
@@ -17,30 +16,28 @@ public class MessageEntity extends AbstractEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "chat_id")
     private Long chatId;
+
+    @Column(name = "sender_id")
     private Long senderId;
-    private String content;
+
+    @Column(name = "body")
+    private String body;
+
+    @Column(name = "is_read")
     private Boolean isRead;
 
     @Enumerated(EnumType.STRING)
     private MessageType messageType;
-
-    @Builder
-    public MessageEntity(Long id, Long chatId, Long senderId, String content, Boolean isRead, MessageType messageType) {
-        this.id = id;
-        this.chatId = chatId;
-        this.senderId = senderId;
-        this.content = content;
-        this.isRead = isRead;
-        this.messageType = messageType;
-    }
 
     public static MessageEntity fromDomain(Message message){
         return MessageEntity.builder()
                 .id(message.getId())
                 .chatId(message.getChatId())
                 .senderId(message.getSenderId())
-                .content(message.getContent())
+                .body(message.getBody())
                 .isRead(message.getIsRead())
                 .messageType(message.getMessageType())
                 .build();
@@ -51,7 +48,7 @@ public class MessageEntity extends AbstractEntity {
                 .id(id)
                 .chatId(chatId)
                 .senderId(senderId)
-                .content(content)
+                .body(body)
                 .isRead(isRead)
                 .messageType(messageType)
                 .build();

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/MessageEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/chat/MessageEntity.java
@@ -21,6 +21,7 @@ public class MessageEntity extends AbstractEntity {
     private Long senderId;
     private String content;
     private Boolean isRead;
+
     @Enumerated(EnumType.STRING)
     private MessageType messageType;
 

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/comment/CommentCoreRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/comment/CommentCoreRepository.java
@@ -22,7 +22,7 @@ public class CommentCoreRepository implements CommentRepository {
                 comment.getId(),
                 comment.getArticleId(),
                 comment.getWriterId(),
-                comment.getContent(),
+                comment.getBody(),
                 comment.getTarget().targetId(),
                 comment.getTarget().type(),
                 comment.getStatus()

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/comment/CommentEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/comment/CommentEntity.java
@@ -6,13 +6,11 @@ import com.app.community.domain.agg.comment.CommentTarget;
 import com.app.community.domain.agg.comment.CommentTargetType;
 import com.app.community.storage.db.command.AbstractEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "comments")
 @Entity
@@ -20,40 +18,30 @@ public class CommentEntity extends AbstractEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "article_id")
     private Long articleId;
+
+    @Column(name = "writer_id")
     private Long writerId;
-    @Lob private String content;
+
+    @Lob @Column(name = "body")
+    private String body;
+
+    @Column(name = "parent_comment_id")
     private Long parentCommentId;
 
     @Enumerated(EnumType.STRING)
     private CommentTargetType targetType;
+
     @Enumerated(EnumType.STRING)
     private CommentStatus status;
-
-    @Builder
-    public CommentEntity(
-            Long id,
-            Long articleId,
-            Long writerId,
-            String content,
-            Long parentCommentId,
-            CommentTargetType targetType,
-            CommentStatus status
-    ) {
-        this.id = id;
-        this.articleId = articleId;
-        this.writerId = writerId;
-        this.content = content;
-        this.parentCommentId = parentCommentId;
-        this.targetType = targetType;
-        this.status = status;
-    }
 
     public Comment toDomain() {
         CommentTarget commentTarget = (articleId.equals(parentCommentId))
                 ? new CommentTarget(articleId, targetType)
                 : new CommentTarget(parentCommentId, targetType);
 
-        return new Comment(id, writerId, articleId, content ,commentTarget, status);
+        return new Comment(id, writerId, articleId, body,commentTarget, status);
     }
 }

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/comment/CommentEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/comment/CommentEntity.java
@@ -22,9 +22,12 @@ public class CommentEntity extends AbstractEntity {
     private Long id;
     private Long articleId;
     private Long writerId;
-    private String content;
+    @Lob private String content;
     private Long parentCommentId;
+
+    @Enumerated(EnumType.STRING)
     private CommentTargetType targetType;
+    @Enumerated(EnumType.STRING)
     private CommentStatus status;
 
     @Builder

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/member/MemberCoreRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/member/MemberCoreRepository.java
@@ -16,21 +16,7 @@ public class MemberCoreRepository implements MemberRepository {
 
     @Override
     public Member save(Member member) {
-        MemberEntity memberEntity = new MemberEntity(
-                member.getId(),
-                member.getProfile().email(),
-                member.getProfile().nickname().value(),
-                member.getProfile().profileImagePath(),
-                member.getProfile().memberSetting().chatPeePoint(),
-                member.getProfile().memberSetting().chatRefusal(),
-                member.getProfile().position(),
-                member.getGrade().value(),
-                member.getGrade().tier(),
-                member.getSocialInfo().socialId(),
-                member.getSocialInfo().memberSocialType(),
-                member.getStatus()
-        );
-        return memberJpaRepository.save(memberEntity).toDomain();
+        return memberJpaRepository.save(MemberEntity.fromDomain(member)).toDomain();
     }
 
 

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/member/MemberEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/member/MemberEntity.java
@@ -5,7 +5,6 @@ import com.app.community.storage.db.command.AbstractEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Setter
 @Getter
 @Builder
 @AllArgsConstructor
@@ -20,14 +19,36 @@ public class MemberEntity extends AbstractEntity {
     private String email;
     private String nickname;
     private String profileImagePath;
+    private String socialId;
     private int chatPeePoint;
     private boolean chatRefusal;
-    private MemberPosition position;
     private int pointValue;
-    private MemberTier tier;
-    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    private MemberPosition position;
+    @Enumerated(EnumType.STRING)
     private MemberSocialType memberSocialType;
+    @Enumerated(EnumType.STRING)
+    private MemberTier tier;
+    @Enumerated(EnumType.STRING)
     private MemberStatus status;
+
+    public static MemberEntity fromDomain(Member member) {
+        return MemberEntity.builder()
+                .id(member.getId())
+                .email(member.getProfile().email())
+                .nickname(member.getProfile().nickname().value())
+                .profileImagePath(member.getProfile().profileImagePath())
+                .chatPeePoint(member.getProfile().memberSetting().chatPeePoint())
+                .chatRefusal(member.getProfile().memberSetting().chatRefusal())
+                .position(member.getProfile().position())
+                .pointValue(member.getGrade().value())
+                .tier(member.getGrade().tier())
+                .socialId(member.getSocialInfo().socialId())
+                .memberSocialType(member.getSocialInfo().memberSocialType())
+                .status(member.getStatus())
+                .build();
+    }
 
     public Member toDomain() {
         MemberNickname memberNickname = new MemberNickname(nickname);

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/member/PointHistoryEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/member/PointHistoryEntity.java
@@ -12,15 +12,15 @@ import lombok.*;
 @Entity
 public class PointHistoryEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long fromMemberId;
     private Long toMemberId;
     private Integer fromMemberBalance;
     private Integer toMemberBalance;
-    private int amount;
+    private Integer amount;
     private Long referenceId;
+
     @Enumerated(EnumType.STRING)
     private PointReferenceType pointReferenceType;
     @Enumerated(EnumType.STRING)

--- a/storage/db-main/src/main/java/com/app/community/storage/db/command/upvote/UpvoteEntity.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/command/upvote/UpvoteEntity.java
@@ -15,13 +15,13 @@ import lombok.*;
 @Entity
 public class UpvoteEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long executorId;
     private Long targetId;
-    private UpvoteTargetType targetType;
 
+    @Enumerated(EnumType.STRING)
+    private UpvoteTargetType targetType;
 
     public Upvote toDomain() {
         UpvoteTarget upvoteTarget = new UpvoteTarget(targetId, targetType);

--- a/storage/db-main/src/main/java/com/app/community/storage/db/query/ArticleMapper.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/query/ArticleMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Mapper
 public interface ArticleMapper {
 
-    List<ArticleInfo> findArticleList(
+    List<ArticleSummary> findArticleList(
             @Param("size") int size,
             @Param("cursor") Long cursor,
             @Param("type") ArticleType type

--- a/storage/db-main/src/main/java/com/app/community/storage/db/query/ArticleQueryRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/query/ArticleQueryRepository.java
@@ -15,7 +15,7 @@ public class ArticleQueryRepository implements ArticleRepositoryForQuery {
     private final ArticleMapper articleMapper;
 
     @Override
-    public List<ArticleInfo> findArticleList(int size, Long cursor, ArticleType type) {
+    public List<ArticleSummary> findArticleList(int size, Long cursor, ArticleType type) {
         return articleMapper.findArticleList(size, cursor, type);
     }
 

--- a/storage/db-main/src/main/java/com/app/community/storage/db/query/ChatMapper.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/query/ChatMapper.java
@@ -1,6 +1,6 @@
 package com.app.community.storage.db.query;
 
-import com.app.community.domain.agg.chat.ChatQuery.ChatInfo;
+import com.app.community.domain.agg.chat.ChatQuery.ChatSummary;
 import com.app.community.domain.agg.chat.ChatQuery.ChatMessageInfo;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -10,7 +10,7 @@ import java.util.List;
 @Mapper
 public interface ChatMapper {
 
-    List<ChatInfo> findChatListByMemberId(
+    List<ChatSummary> findChatListByMemberId(
             @Param("memberId") Long memberId,
             @Param("size") int size,
             @Param("cursor") Long cursor

--- a/storage/db-main/src/main/java/com/app/community/storage/db/query/ChatQueryRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/query/ChatQueryRepository.java
@@ -14,7 +14,7 @@ public class ChatQueryRepository implements ChatRepositoryForQuery {
     private final ChatMapper chatMapper;
 
     @Override
-    public List<ChatInfo> findChatListByMemberId(Long memberId, int size, Long cursor) {
+    public List<ChatSummary> findChatListByMemberId(Long memberId, int size, Long cursor) {
         return chatMapper.findChatListByMemberId(memberId, size, cursor);
     }
 

--- a/storage/db-main/src/main/java/com/app/community/storage/db/query/CommentMapper.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/query/CommentMapper.java
@@ -1,6 +1,6 @@
 package com.app.community.storage.db.query;
 
-import com.app.community.domain.agg.comment.CommentQuery.CommentInfo;
+import com.app.community.domain.agg.comment.CommentQuery.*;
 import com.app.community.domain.agg.comment.CommentQuery.ProfileComment;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -10,7 +10,7 @@ import java.util.List;
 @Mapper
 public interface CommentMapper {
 
-    List<CommentInfo> findCommentListByArticleId(
+    List<CommentDetails> findCommentListByArticleId(
             @Param("articleId") Long articleId,
             @Param("size") int size,
             @Param("cursor") Long cursor

--- a/storage/db-main/src/main/java/com/app/community/storage/db/query/CommentQueryRepository.java
+++ b/storage/db-main/src/main/java/com/app/community/storage/db/query/CommentQueryRepository.java
@@ -14,7 +14,7 @@ public class CommentQueryRepository implements CommentRepositoryForQuery {
     private final CommentMapper commentMapper;
 
     @Override
-    public List<CommentInfo> findCommentListByArticleId(Long articleId, int size, Long cursor) {
+    public List<CommentDetails> findCommentListByArticleId(Long articleId, int size, Long cursor) {
         return commentMapper.findCommentListByArticleId(articleId, size, cursor);
     }
 

--- a/storage/db-main/src/main/resources/db-main.yml
+++ b/storage/db-main/src/main/resources/db-main.yml
@@ -2,25 +2,15 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate.default_batch_fetch_size: 100
 
 mybatis:
   mapper-locations: classpath:mapper/*.xml
 
-
 ---
 spring.config.activate.on-profile: local
-
-spring:
-  jpa:
-    hibernate:
-      ddl-auto: none
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
 
 storage:
   datasource:

--- a/storage/db-main/src/main/resources/mapper/ArticleMapper.xml
+++ b/storage/db-main/src/main/resources/mapper/ArticleMapper.xml
@@ -4,32 +4,33 @@
 <mapper namespace="com.app.community.storage.db.query.ArticleMapper">
 
     <!-- 게시글 리스트 조회 -->
-    <select id="findArticleList" resultMap="ArticleInfoMap">
+    <select id="findArticleList" resultMap="ArticleSummaryMap">
         SELECT
-            a.id AS articleId,
+            a.id,
             a.title,
-            a.content,
-            a.article_type AS articleType,
-            m.id AS memberId,
-             m.nickname,
+            a.body,
+            a.type,
+            a.created_at AS articleCreatedAt,
+            a.updated_at AS articleUpdatedAt,
+            m.id AS writerId,
+            m.nickname,
             m.profile_image_path AS profileImagePath,
             m.created_at AS memberCreatedAt,
             m.updated_at AS memberUpdatedAt,
-            a.created_at AS articleCreatedAt,
-            a.updated_at AS articleUpdatedAt,
-            ak.keyword_id AS keywordId,
-            ak.keyword_name AS keywordName
+            k.id AS keywordId,
+            k.name AS keywordName
         FROM
             articles a
-        LEFT JOIN members m ON a.member_id = m.id
+        LEFT JOIN members m ON a.writer_id = m.id
         LEFT JOIN article_keywords ak ON ak.article_id = a.id
+        LEFT JOIN keywords k ON ak.keyword_id = k.id
         WHERE
-        a.article_status = 'STEADY'
+        a.status = 'STEADY'
         <if test="cursor != null and cursor != -1">
             AND a.id &lt; #{cursor}
         </if>
         <if test="type != null">
-            AND a.article_type = #{type}
+            AND a.type = #{type}
         </if>
         ORDER BY a.id DESC
         LIMIT #{size}
@@ -38,26 +39,27 @@
     <!-- 게시글 상세 조회 -->
     <select id="findArticleDetails" resultMap="ArticleDetailsMap">
         SELECT
-            a.id AS articleId,
+            a.id,
             a.title,
-            a.content,
-            a.article_type AS articleType,
-            m.id AS memberId,
+            a.body,
+            a.type,
+            a.created_at AS articleCreatedAt,
+            a.updated_at AS articleUpdatedAt,
+            m.id AS writerId,
             m.nickname,
             m.profile_image_path AS profileImagePath,
             m.created_at AS memberCreatedAt,
             m.updated_at AS memberUpdatedAt,
-            a.created_at AS articleCreatedAt,
-            a.updated_at AS articleUpdatedAt,
-            ak.keyword_id AS keywordId,
-            ak.keyword_name AS keywordName
+            k.id AS keywordId,
+            k.name AS keywordName
         FROM
             articles a
-                LEFT JOIN members m ON a.member_id = m.id
-                LEFT JOIN article_keywords ak ON ak.article_id = a.id
+        LEFT JOIN members m ON a.writer_id = m.id
+        LEFT JOIN article_keywords ak ON ak.article_id = a.id
+        LEFT JOIN keywords k ON ak.keyword_id = k.id
         WHERE
             a.id = #{articleId}
-          AND a.article_status = 'STEADY'
+          AND a.status = 'STEADY'
     </select>
 
     <!-- 회원별 게시글 리스트 조회 -->
@@ -65,56 +67,85 @@
         SELECT
             a.id AS articleId,
             a.title,
-            a.content,
-            a.article_type AS articleType,
-            a.created_at AS articleCreatedAt,
-            a.updated_at AS articleUpdatedAt
+            a.body,
+            a.type,
+            a.created_at AS createdAt,
+            a.updated_at AS updatedAt
         FROM
             articles a
         WHERE
-            a.article_status = 'STEADY'
-        AND a.member_id = #{memberId}
+            a.status = 'STEADY'
+        AND a.writer_id = #{memberId}
         <if test="cursor != null and cursor != -1">
             AND a.id &lt; #{cursor}
         </if>
         <if test="type != null">
-            AND a.article_type = #{type}
+            AND a.type = #{type}
         </if>
         ORDER BY a.id DESC
         LIMIT #{size}
     </select>
 
-    <resultMap id="ArticleInfoMap" type="ArticleInfo">
-        <id column="articleId" property="articleId"/>
-        <result column="title" property="title"/>
-        <result column="content" property="content"/>
-        <result column="articleType" property="articleType"/>
+    <resultMap id="ArticleSummaryMap" type="ArticleSummary">
+        <id column="id" property="id"/>
+
+        <result column="type" property="type"/>
+
         <result column="articleCreatedAt" property="createdAt"/>
         <result column="articleUpdatedAt" property="updatedAt"/>
 
-        <association property="author" javaType="Author">
-            <id column="memberId" property="memberId"/>
+        <association property="content" javaType="ArticleContentInfo">
+            <result column="title" property="title"/>
+            <result column="body" property="body"/>
+        </association>
+
+        <association property="author" javaType="ArticleAuthor">
+            <id column="writerId" property="id"/>
             <result column="nickname" property="nickname"/>
             <result column="profileImagePath" property="profileImagePath"/>
             <result column="memberCreatedAt" property="createdAt"/>
             <result column="memberUpdatedAt" property="updatedAt"/>
         </association>
 
-        <collection property="keywordList" ofType="ArticleKeywordInfo">
-            <id column="keywordId" property="keywordId"/>
-            <result column="keywordName" property="keywordName"/>
+        <collection property="keywords" ofType="ArticleKeywordInfo">
+            <id column="keywordId" property="id"/>
+            <result column="keywordName" property="name"/>
         </collection>
     </resultMap>
 
-    <resultMap id="ArticleDetailsMap" type="ArticleDetails" extends="ArticleInfoMap"/>
 
-    <resultMap id="ArticleActivityMap" type="ArticleActivity">
-        <id column="articleId" property="articleId"/>
-        <result column="title" property="title"/>
-        <result column="content" property="content"/>
-        <result column="articleType" property="articleType"/>
+    <resultMap id="ArticleDetailsMap" type="ArticleDetails">
+        <id column="id" property="id"/>
+        <result column="type" property="type"/>
         <result column="articleCreatedAt" property="createdAt"/>
         <result column="articleUpdatedAt" property="updatedAt"/>
+        <association property="content" javaType="ArticleContentInfo">
+            <result column="title" property="title"/>
+            <result column="body" property="body"/>
+        </association>
+        <association property="author" javaType="ArticleAuthor">
+            <id column="writerId" property="id"/>
+            <result column="nickname" property="nickname"/>
+            <result column="profileImagePath" property="profileImagePath"/>
+            <result column="memberCreatedAt" property="createdAt"/>
+            <result column="memberUpdatedAt" property="updatedAt"/>
+        </association>
+        <collection property="keywords" ofType="ArticleKeywordInfo">
+            <id column="keywordId" property="id"/>
+            <result column="keywordName" property="name"/>
+        </collection>
     </resultMap>
+
+    <resultMap id="ArticleActivityMap" type="ArticleActivity">
+        <id column="id" property="id"/>
+        <result column="articleType" property="articleType"/>
+        <result column="createdAt" property="createdAt"/>
+        <result column="updatedAt" property="updatedAt"/>
+        <association property="contentInfo" javaType="ArticleContentInfo">
+            <result column="title" property="title"/>
+            <result column="body" property="body"/>
+        </association>
+    </resultMap>
+
 
 </mapper>

--- a/storage/db-main/src/main/resources/mapper/ChatMapper.xml
+++ b/storage/db-main/src/main/resources/mapper/ChatMapper.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.app.community.storage.db.query.ChatMapper">
 
-    <!-- 회원 ID로 채팅 목록 조회 -->
     <select id="findChatListByMemberId" resultMap="ChatInfoMap">
         SELECT
             c.id as chatId,
@@ -51,18 +50,14 @@
         LIMIT 21
     </select>
 
-    <!-- Result Map Definitions -->
     <resultMap id="ChatInfoMap" type="ChatInfo">
-        <!-- 먼저 ID 요소 정의 -->
         <id column="chatId" property="chatId"/>
 
-        <!-- 그다음 result 요소 정의 -->
         <result column="lastMessageContent" property="lastMessages"/>
         <result column="lastMessageCreatedAt" property="lastUpdatedAt"/>
         <result column="chatCreatedAt" property="createdAt"/>
         <result column="chatEndAt" property="endDate"/>
 
-        <!-- 그다음 association 요소 정의 -->
         <association property="sender" javaType="Participant">
             <id column="requesterId" property="memberId"/>
             <result column="requesterNickname" property="nickname"/>
@@ -75,17 +70,14 @@
     </resultMap>
 
     <resultMap id="ChatMessageInfoMap" type="ChatMessageInfo">
-        <!-- 먼저 ID 요소 정의 -->
         <id column="messageId" property="messageId"/>
 
-        <!-- 그다음 result 요소 정의 -->
         <result column="chatId" property="chatId"/>
         <result column="content" property="content"/>
         <result column="messageCreatedAt" property="createdAt"/>
         <result column="messageType" property="messageType"/>
         <result column="isRead" property="isRead"/>
 
-        <!-- 그다음 association 요소 정의 -->
         <association property="sender" javaType="Participant">
             <id column="senderId" property="memberId"/>
             <result column="senderNickname" property="nickname"/>

--- a/storage/db-main/src/main/resources/mapper/ChatMapper.xml
+++ b/storage/db-main/src/main/resources/mapper/ChatMapper.xml
@@ -2,84 +2,88 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.app.community.storage.db.query.ChatMapper">
 
-    <select id="findChatListByMemberId" resultMap="ChatInfoMap">
+    <!--채팅방조회-->
+    <select id="findChatListByMemberId" resultMap="ChatSummaryMap">
         SELECT
             c.id as chatId,
             r.id as requesterId,
             r.nickname as requesterNickname,
             s.id as respondentId,
             s.nickname as respondentNickname,
-            m.content as lastMessageContent,
+            m.body as lastMessageBody,
             m.created_at as lastMessageCreatedAt,
             c.created_at as chatCreatedAt,
             c.end_at as chatEndAt
         FROM
-            chat c
-                LEFT JOIN message m ON m.id = (
+            chats c
+                LEFT JOIN chat_messages m ON m.id = (
                 SELECT MAX(id)
-                FROM message
+                FROM chat_messages m
                 WHERE chat_id = c.id
             )
-                LEFT JOIN member r ON c.requester_id = r.id
-                LEFT JOIN member s ON c.respondent_id = s.id
+                LEFT JOIN members r ON c.requester_id = r.id
+                LEFT JOIN members s ON c.respondent_id = s.id
         WHERE
             c.requester_id = #{memberId}
            OR c.respondent_id = #{memberId}
     </select>
 
-    <!-- 채팅 메시지 목록 조회 -->
+    <!-- 채팅 메시지 리스트 조회 -->
     <select id="findChatMessageList" resultMap="ChatMessageInfoMap">
         SELECT
-        m.id as messageId,
-        m.chat_id as chatId,
-        s.id as senderId,
-        s.nickname as senderNickname,
-        m.content,
-        m.created_at as messageCreatedAt,
-        m.message_type as messageType,
-        m.is_read as isRead
+            cm.id as messageId,
+            cm.chat_id as chatId,
+            m.id as senderId,
+            m.nickname as senderNickname,
+            cm.body,
+            cm.created_at as messageCreatedAt,
+            cm.message_type as messageType,
+            cm.is_read as isRead
         FROM
-        message m
-        LEFT JOIN member s ON m.sender_id = s.id
+            chat_messages cm
+        LEFT JOIN members m ON cm.sender_id = m.id
         WHERE
-        m.chat_id = #{chatId}
-        <if test="cursor != null and cursor != -1">
-            AND m.id &lt; #{cursor}
-        </if>
+            cm.chat_id = #{chatId}
+            <if test="cursor != null and cursor != -1">
+                AND m.id &lt; #{cursor}
+            </if>
         ORDER BY m.id DESC
         LIMIT 21
     </select>
 
-    <resultMap id="ChatInfoMap" type="ChatInfo">
-        <id column="chatId" property="chatId"/>
+    <resultMap id="ChatSummaryMap" type="ChatSummary">
+        <id column="chatId" property="id"/>
 
-        <result column="lastMessageContent" property="lastMessages"/>
+        <result column="lastMessageBody" property="lastMessage"/>
         <result column="lastMessageCreatedAt" property="lastUpdatedAt"/>
-        <result column="chatCreatedAt" property="createdAt"/>
-        <result column="chatEndAt" property="endDate"/>
+
+        <association property="period" javaType="ChatDateTimeInfo">
+            <result column="chatCreatedAt" property="createdAt"/>
+            <result column="chatEndAt" property="endDate"/>
+        </association>
 
         <association property="sender" javaType="Participant">
-            <id column="requesterId" property="memberId"/>
+            <id column="requesterId" property="id"/>
             <result column="requesterNickname" property="nickname"/>
         </association>
 
         <association property="receiver" javaType="Participant">
-            <id column="respondentId" property="memberId"/>
+            <id column="respondentId" property="id"/>
             <result column="respondentNickname" property="nickname"/>
         </association>
     </resultMap>
 
     <resultMap id="ChatMessageInfoMap" type="ChatMessageInfo">
-        <id column="messageId" property="messageId"/>
+        <id column="messageId" property="id"/>
 
         <result column="chatId" property="chatId"/>
-        <result column="content" property="content"/>
+        <result column="body" property="body"/>
         <result column="messageCreatedAt" property="createdAt"/>
         <result column="messageType" property="messageType"/>
         <result column="isRead" property="isRead"/>
 
         <association property="sender" javaType="Participant">
-            <id column="senderId" property="memberId"/>
+            <id column="senderId" property="id"/>
             <result column="senderNickname" property="nickname"/>
         </association>
     </resultMap>

--- a/storage/db-main/src/main/resources/mapper/CommentMapper.xml
+++ b/storage/db-main/src/main/resources/mapper/CommentMapper.xml
@@ -2,38 +2,36 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.app.community.storage.db.query.CommentMapper">
 
-    <select id="findCommentListByArticleId" resultMap="CommentInfoMap">
+    <select id="findCommentListByArticleId" resultMap="CommentDetailsMap">
         SELECT
-        c.id as commentId,
-        c.article_id as articleId,
-        c.parent_comment_id as parentId,
-        c.content,
-        c.status,
-        c.created_at as createdAt,
-        c.updated_at as updatedAt,
-        m.id as memberId,
-        m.nickname,
-        m.profile_image_path as profileImagePath,
-        m.created_at as memberCreatedAt,
-        m.updated_at as memberUpdatedAt,
-        child.id as childCommentId,
-        child.content as childContent,
-        child.created_at as childCreatedAt,
-        child.updated_at as childUpdatedAt,
-        child.status as childStatus,
-        childMember.id as childMemberId,
-        childMember.nickname as childMemberNickname,
-        childMember.profile_image_path as childMemberProfileImagePath,
-        childMember.created_at as childMemberCreatedAt,
-        childMember.updated_at as childMemberUpdatedAt
+            c.id,
+            c.article_id as articleId,
+            c.parent_comment_id as parentId,
+            c.body,
+            c.status,
+            c.created_at as createdAt,
+            m.id as writerId,
+            m.nickname,
+            m.created_at as memberCreatedAt,
+            m.updated_at as memberUpdatedAt,
+            ch.id as childId,
+            ch.content as childBody,
+            ch.created_at as childCreatedAt,
+            ch.updated_at as childUpdatedAt,
+            ch.status as childStatus,
+            cm.id as childWriterId,
+            cm.nickname as childWriterNickname,
+            cm.profile_image_path as childWriterProfileImagePath,
+            cm.created_at as childWriterCreatedAt,
+            cm.updated_at as childWriterUpdatedAt
         FROM
-        comment c
-        LEFT JOIN member m ON c.writer_id = m.id
-        LEFT JOIN comment child ON child.parent_comment_id = c.id
-        LEFT JOIN member childMember ON child.writer_id = childMember.id
+            comments c
+        LEFT JOIN members m ON c.writer_id = m.id
+        LEFT JOIN comments ch ON c.parent_comment_id = ch.id
+        LEFT JOIN members cm ON c.writer_id = cm.id
         WHERE
-        c.article_id = #{articleId}
-        AND c.parent_comment_id IS NULL
+            c.article_id = #{articleId}
+            AND c.parent_comment_id IS NULL
         <if test="cursor != null and cursor != -1">
             AND c.id &lt; #{cursor}
         </if>
@@ -44,19 +42,19 @@
     <!-- 회원의 답글 목록 조회 -->
     <select id="findAnswerByMember" resultMap="ProfileCommentMap">
         SELECT
-        c.id as commentId,
-        c.article_id as articleId,
-        a.title as articleTitle,
-        c.content,
-        c.status,
-        c.created_at as createdAt,
-        c.updated_at as updatedAt
+            c.id as id,
+            c.article_id as articleId,
+            a.title as articleTitle,
+            c.body,
+            c.status,
+            c.created_at as createdAt,
+            c.updated_at as updatedAt
         FROM
-        comment c
-        LEFT JOIN article a ON a.id = c.article_id
+            comments c
+        LEFT JOIN articles a ON a.id = c.article_id
         WHERE
-        c.writer_id = #{memberId}
-        AND c.parent_comment_id IS NULL
+            c.writer_id = #{memberId}
+            AND c.parent_comment_id IS NULL
         <if test="cursor != null and cursor != -1">
             AND c.id &lt; #{cursor}
         </if>
@@ -64,43 +62,44 @@
         LIMIT 20
     </select>
 
-    <resultMap id="CommentInfoMap" type="CommentInfo">
-        <id column="commentId" property="commentId"/>
+    <resultMap id="CommentDetailsMap" type="CommentDetails">
+        <id column="id" property="id"/>
         <result column="articleId" property="articleId"/>
         <result column="parentId" property="parentId"/>
-        <result column="content" property="content"/>
+        <result column="body" property="content"/>
         <result column="status" property="status"/>
         <result column="createdAt" property="createdAt"/>
         <result column="updatedAt" property="updatedAt"/>
 
         <association property="author" javaType="CommentAuthor">
-            <id column="memberId" property="memberId"/>
+            <id column="writerId" property="id"/>
             <result column="nickname" property="nickname"/>
             <result column="profileImagePath" property="profileImagePath"/>
             <result column="memberCreatedAt" property="createdAt"/>
             <result column="memberUpdatedAt" property="updatedAt"/>
         </association>
 
-        <collection property="childCommentList" ofType="CommentInfo">
-            <id column="childCommentId" property="commentId"/>
+        <collection property="children" ofType="CommentDetails">
+            <id column="childId" property="id"/>
             <result column="articleId" property="articleId"/>
-            <result column="content" property="content"/>
-            <result column="status" property="status"/>
-            <result column="createdAt" property="createdAt"/>
-            <result column="updatedAt" property="updatedAt"/>
+            <result column="childBody" property="content"/>
+            <result column="childStatus" property="status"/>
+            <result column="childCreatedAt" property="createdAt"/>
+            <result column="childUpdatedAt" property="updatedAt"/>
 
             <association property="author" javaType="CommentAuthor">
-                <id column="childMemberId" property="memberId"/>
-                <result column="childMemberNickname" property="nickname"/>
-                <result column="childMemberProfileImagePath" property="profileImagePath"/>
-                <result column="childMemberCreatedAt" property="createdAt"/>
-                <result column="childMemberUpdatedAt" property="updatedAt"/>
+                <id column="childWriterId" property="id"/>
+                <result column="childWriterNickname" property="nickname"/>
+                <result column="childWriterProfileImagePath" property="profileImagePath"/>
+                <result column="childWriterCreatedAt" property="createdAt"/>
+                <result column="childWriterUpdatedAt" property="updatedAt"/>
             </association>
         </collection>
     </resultMap>
 
+
     <resultMap id="ProfileCommentMap" type="ProfileComment">
-        <id column="commentId" property="commentId"/>
+        <id column="id" property="commentId"/>
         <result column="articleId" property="articleId"/>
         <result column="articleTitle" property="articleTitle"/>
         <result column="content" property="content"/>

--- a/storage/db-main/src/main/resources/mapper/CommentMapper.xml
+++ b/storage/db-main/src/main/resources/mapper/CommentMapper.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.app.community.storage.db.query.CommentMapper">
 
-    <!-- 특정 Article ID로 댓글 목록 조회 -->
     <select id="findCommentListByArticleId" resultMap="CommentInfoMap">
         SELECT
         c.id as commentId,
@@ -65,7 +64,6 @@
         LIMIT 20
     </select>
 
-    <!-- Result Map Definitions -->
     <resultMap id="CommentInfoMap" type="CommentInfo">
         <id column="commentId" property="commentId"/>
         <result column="articleId" property="articleId"/>
@@ -75,7 +73,6 @@
         <result column="createdAt" property="createdAt"/>
         <result column="updatedAt" property="updatedAt"/>
 
-        <!-- Author 정보 매핑 -->
         <association property="author" javaType="CommentAuthor">
             <id column="memberId" property="memberId"/>
             <result column="nickname" property="nickname"/>
@@ -84,7 +81,6 @@
             <result column="memberUpdatedAt" property="updatedAt"/>
         </association>
 
-        <!-- 자식 댓글 목록 매핑 -->
         <collection property="childCommentList" ofType="CommentInfo">
             <id column="childCommentId" property="commentId"/>
             <result column="articleId" property="articleId"/>
@@ -93,7 +89,6 @@
             <result column="createdAt" property="createdAt"/>
             <result column="updatedAt" property="updatedAt"/>
 
-            <!-- 자식 댓글 작성자 정보 매핑 -->
             <association property="author" javaType="CommentAuthor">
                 <id column="childMemberId" property="memberId"/>
                 <result column="childMemberNickname" property="nickname"/>

--- a/storage/db-main/src/main/resources/mybatis-config.xml
+++ b/storage/db-main/src/main/resources/mybatis-config.xml
@@ -4,23 +4,20 @@
 <configuration>
     <typeAliases>
 
-        <!--조회모델 래퍼-->
         <typeAlias alias="ArticleContentInfo" type="com.app.community.domain.agg.article.ArticleQuery$ArticleContentInfo"/>
         <typeAlias alias="ArticleAuthor" type="com.app.community.domain.agg.article.ArticleQuery$ArticleAuthor"/>
         <typeAlias alias="ArticleKeywordInfo" type="com.app.community.domain.agg.article.ArticleQuery$ArticleKeywordInfo"/>
 
-        <!--아티클 조회모델-->
         <typeAlias alias="ArticleSummary" type="com.app.community.domain.agg.article.ArticleQuery$ArticleSummary"/>
         <typeAlias alias="ArticleActivity" type="com.app.community.domain.agg.article.ArticleQuery$ArticleActivity"/>
         <typeAlias alias="ArticleDetails" type="com.app.community.domain.agg.article.ArticleQuery$ArticleDetails"/>
 
-
-        <typeAlias alias="ChatInfo" type="com.app.community.domain.agg.chat.ChatQuery$ChatInfo"/>
+        <typeAlias alias="ChatSummary" type="com.app.community.domain.agg.chat.ChatQuery$ChatSummary"/>
         <typeAlias alias="ChatMessageInfo" type="com.app.community.domain.agg.chat.ChatQuery$ChatMessageInfo"/>
         <typeAlias alias="Participant" type="com.app.community.domain.agg.chat.ChatQuery$Participant"/>
+        <typeAlias alias="ChatDateTimeInfo" type="com.app.community.domain.agg.chat.ChatQuery$ChatDateTimeInfo"/>
 
-
-        <typeAlias alias="CommentInfo" type="com.app.community.domain.agg.comment.CommentQuery$CommentInfo"/>
+        <typeAlias alias="CommentDetails" type="com.app.community.domain.agg.comment.CommentQuery$CommentDetails"/>
         <typeAlias alias="ProfileComment" type="com.app.community.domain.agg.comment.CommentQuery$ProfileComment"/>
         <typeAlias alias="CommentAuthor" type="com.app.community.domain.agg.comment.CommentQuery$CommentAuthor"/>
     </typeAliases>

--- a/storage/db-main/src/main/resources/mybatis-config.xml
+++ b/storage/db-main/src/main/resources/mybatis-config.xml
@@ -3,11 +3,16 @@
 
 <configuration>
     <typeAliases>
-        <typeAlias alias="ArticleInfo" type="com.app.community.domain.agg.article.ArticleQuery$ArticleInfo"/>
-        <typeAlias alias="ArticleDetails" type="com.app.community.domain.agg.article.ArticleQuery$ArticleDetails"/>
-        <typeAlias alias="ArticleActivity" type="com.app.community.domain.agg.article.ArticleQuery$ArticleActivity"/>
-        <typeAlias alias="Author" type="com.app.community.domain.agg.article.ArticleQuery$Author"/>
+
+        <!--조회모델 래퍼-->
+        <typeAlias alias="ArticleContentInfo" type="com.app.community.domain.agg.article.ArticleQuery$ArticleContentInfo"/>
+        <typeAlias alias="ArticleAuthor" type="com.app.community.domain.agg.article.ArticleQuery$ArticleAuthor"/>
         <typeAlias alias="ArticleKeywordInfo" type="com.app.community.domain.agg.article.ArticleQuery$ArticleKeywordInfo"/>
+
+        <!--아티클 조회모델-->
+        <typeAlias alias="ArticleSummary" type="com.app.community.domain.agg.article.ArticleQuery$ArticleSummary"/>
+        <typeAlias alias="ArticleActivity" type="com.app.community.domain.agg.article.ArticleQuery$ArticleActivity"/>
+        <typeAlias alias="ArticleDetails" type="com.app.community.domain.agg.article.ArticleQuery$ArticleDetails"/>
 
 
         <typeAlias alias="ChatInfo" type="com.app.community.domain.agg.chat.ChatQuery$ChatInfo"/>
@@ -17,6 +22,6 @@
 
         <typeAlias alias="CommentInfo" type="com.app.community.domain.agg.comment.CommentQuery$CommentInfo"/>
         <typeAlias alias="ProfileComment" type="com.app.community.domain.agg.comment.CommentQuery$ProfileComment"/>
-        <typeAlias alias="CommentAuthor" type="com.app.community.domain.agg.comment.CommentQuery$Author"/>
+        <typeAlias alias="CommentAuthor" type="com.app.community.domain.agg.comment.CommentQuery$CommentAuthor"/>
     </typeAliases>
 </configuration>


### PR DESCRIPTION
### 추가
- ARTICLE 조회용 컨트롤러 Rest docs test 
- COMMENT 조회용 컨트롤러 Rest docs test 
- CHAT 조회용 컨트롤러 Rest docs test


### 변경
- content 필드와 content 객체 이름 중복으로 인한 content -> body 필드로 변경 [content 를 포함하는 도메인]
- 모든 중복되는 필드, 컬럼 네이밍 모두 변경 [ 예시 : Article 클래스의 articldId -> id]
- 컬럼 변경에 따른 DB 모듈 및 조회 모델 변경
